### PR TITLE
Add support for non-square 2D Array tables with headers

### DIFF
--- a/Sources/Table/Table.swift
+++ b/Sources/Table/Table.swift
@@ -115,7 +115,7 @@ public enum TableSpacing {
         let inputData = data as! [[String]]
         var info = tableInfo(data: inputData)
         if let header = header {
-            assert(inputData.map({ $0.count }).allSatisfy({ $0 == header.count }), "header should be equal items")
+            assert(inputData.map({ $0.count }).max() == header.count, "header should be equal items")
             for (index, title) in header.enumerated() {
                 let infoWidth = info.widthInfo[index]!
                 info.widthInfo[index] = max(infoWidth, title.count)
@@ -130,7 +130,7 @@ public enum TableSpacing {
         let inputData = data as! [[Int]]
         var info = tableInfo(data: inputData)
         if let header = header {
-            assert(inputData.map({ $0.count }).allSatisfy({ $0 == header.count }), "header should be equal items")
+            assert(inputData.map({ $0.count }).max() == header.count, "header should be equal items")
             for (index, title) in header.enumerated() {
                 let infoWidth = info.widthInfo[index]!
                 info.widthInfo[index] = max(infoWidth, title.count)
@@ -145,7 +145,7 @@ public enum TableSpacing {
         let inputData = data as! [[Double]]
         var info = tableInfo(data: inputData)
         if let header = header {
-            assert(inputData.map({ $0.count }).allSatisfy({ $0 == header.count }), "header should be equal items")
+            assert(inputData.map({ $0.count }).max() == header.count, "header should be equal items")
             for (index, title) in header.enumerated() {
                 let infoWidth = info.widthInfo[index]!
                 info.widthInfo[index] = max(infoWidth, title.count)

--- a/Sources/Table/Table.swift
+++ b/Sources/Table/Table.swift
@@ -115,7 +115,7 @@ public enum TableSpacing {
         let inputData = data as! [[String]]
         var info = tableInfo(data: inputData)
         if let header = header {
-            assert(header.count == inputData.count, "header should be equal items")
+            assert(inputData.map({ $0.count }).allSatisfy({ $0 == header.count }), "header should be equal items")
             for (index, title) in header.enumerated() {
                 let infoWidth = info.widthInfo[index]!
                 info.widthInfo[index] = max(infoWidth, title.count)
@@ -130,7 +130,7 @@ public enum TableSpacing {
         let inputData = data as! [[Int]]
         var info = tableInfo(data: inputData)
         if let header = header {
-            assert(header.count == inputData.count, "header should be equal items")
+            assert(inputData.map({ $0.count }).allSatisfy({ $0 == header.count }), "header should be equal items")
             for (index, title) in header.enumerated() {
                 let infoWidth = info.widthInfo[index]!
                 info.widthInfo[index] = max(infoWidth, title.count)
@@ -145,7 +145,7 @@ public enum TableSpacing {
         let inputData = data as! [[Double]]
         var info = tableInfo(data: inputData)
         if let header = header {
-            assert(header.count == inputData.count, "header should be equal items")
+            assert(inputData.map({ $0.count }).allSatisfy({ $0 == header.count }), "header should be equal items")
             for (index, title) in header.enumerated() {
                 let infoWidth = info.widthInfo[index]!
                 info.widthInfo[index] = max(infoWidth, title.count)


### PR DESCRIPTION
Fixes an issue where tables with headers and "non-square" 2D data arrays. This means that tables like this one are now possible to create

```
+-----+------+
|Index|Words |
+-----+------+
|1    |HELLOW|
+-----+------+
|2    |WOLLEH|
+-----+------+
|3    |HELLOW|
+-----+------+
|4    |WOLLEH|
+-----+------+
```

Previously, the library would crash with an assertion failure. My solution still checks for rows with an invalid length.